### PR TITLE
Simplify compilation for other platfroms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,22 @@
 cmake_minimum_required (VERSION 3.5)
 if (NOT DEFINED CMAKE_CXX_COMPILER)
-  set(CMAKE_CXX_COMPILER /usr/bin/clang++-6.0)
+  set(CMAKE_CXX_COMPILER /usr/bin/clang++)
 endif()
 
 project(StarkwareCryptoLib VERSION 0.1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
 include(CTest)
-# Basic setup for gtest
-find_package(GTest REQUIRED)
-include_directories(${GTEST_INCLUDE_DIRS})
 enable_testing()
 include_directories("${CMAKE_SOURCE_DIR}/src")
 

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ This repo requires the installation of the Golang compiler on the system in orde
 presubmit script and the provided Go FFI and test. To install Go under Ubuntu, run the following:
 
 ``sudo apt install golang-go``
+
+For 32-bit builds to work, boost library is required.

--- a/presubmit.sh
+++ b/presubmit.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-(cd src/starkware/crypto/ffi/js; npm install)
+(cd src/starkware/crypto/ffi/js; npm install --no-package-lock)
 
 mkdir -p build/Release
 (cd build/Release; cmake -DCMAKE_BUILD_TYPE=Release ../..)
 make -C build/Release
 CTEST_OUTPUT_ON_FAILURE=1 make -C build/Release test
-clang-tidy-6.0 -header-filter=src/starkware -p=build/Release $(find src/starkware -name "*.cc" | grep -v node_modules)
+clang-tidy -header-filter=src/starkware -p=build/Release $(find src/starkware -name "*.cc" | grep -v node_modules)
 cpplint --extensions=cc,h $(find src/starkware | grep -v node_modules | grep -E '\.(cc|h)$')

--- a/src/starkware/algebra/CMakeLists.txt
+++ b/src/starkware/algebra/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(algebra prime_field_element.cc)
 
 add_executable(big_int_test big_int_test.cc)
-target_link_libraries(big_int_test gtest gtest_main pthread)
+target_link_libraries(big_int_test gtest gtest_main gmock pthread)
 add_test(big_int_test big_int_test)
 
 add_executable(prime_field_element_test prime_field_element_test.cc)
@@ -9,9 +9,9 @@ target_link_libraries(prime_field_element_test algebra gtest gtest_main pthread)
 add_test(prime_field_element_test prime_field_element_test)
 
 add_executable(fraction_field_element_test fraction_field_element_test.cc)
-target_link_libraries(fraction_field_element_test algebra gtest gtest_main pthread)
+target_link_libraries(fraction_field_element_test algebra gtest gtest_main gmock pthread)
 add_test(fraction_field_element_test fraction_field_element_test)
 
 add_executable(elliptic_curve_test elliptic_curve_test.cc)
-target_link_libraries(elliptic_curve_test algebra gtest gtest_main pthread)
+target_link_libraries(elliptic_curve_test algebra gtest gtest_main gmock pthread)
 add_test(elliptic_curve_test elliptic_curve_test)

--- a/src/starkware/algebra/big_int.h
+++ b/src/starkware/algebra/big_int.h
@@ -13,6 +13,14 @@
 #include "starkware/utils/error_handling.h"
 #include "starkware/utils/prng.h"
 
+/*
+    Support for 32-bit builds, where __uint128_t isn't defined.
+*/
+#ifndef __SIZEOF_INT128__
+  #include <boost/multiprecision/cpp_int.hpp>
+  typedef boost::multiprecision::uint128_t __uint128_t;
+#endif
+
 namespace starkware {
 
 static constexpr inline __uint128_t Umul128(uint64_t x, uint64_t y) {

--- a/src/starkware/crypto/CMakeLists.txt
+++ b/src/starkware/crypto/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(crypto elliptic_curve_constants.cc pedersen_hash.cc ecdsa.cc)
 target_link_libraries(crypto algebra)
 
 add_executable(elliptic_curve_constants_test elliptic_curve_constants_test.cc)
-target_link_libraries(elliptic_curve_constants_test gtest crypto gtest_main pthread)
+target_link_libraries(elliptic_curve_constants_test gtest crypto gtest_main gmock pthread)
 add_test(elliptic_curve_constants_test elliptic_curve_constants_test)
 
 add_executable(pedersen_hash_test pedersen_hash_test.cc)

--- a/src/starkware/crypto/ffi/js/CMakeLists.txt
+++ b/src/starkware/crypto/ffi/js/CMakeLists.txt
@@ -1,14 +1,14 @@
 add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto_c_exports.so
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto
     COMMAND
         ${CMAKE_COMMAND} -E copy
-        ${CMAKE_CURRENT_BINARY_DIR}/../libcrypto_c_exports.so
-        ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto_c_exports.so
+        ${CMAKE_CURRENT_BINARY_DIR}/../libcrypto_c_exports.*
+        ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS crypto_c_exports
 )
 
 add_custom_target(js_test ALL
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto_c_exports.so
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto
 )
 
 add_test(

--- a/src/starkware/crypto/ffi/js/package.json
+++ b/src/starkware/crypto/ffi/js/package.json
@@ -15,7 +15,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "bigint-buffer": "^1.1.5",
-    "bn": "^1.0.5",
+    "bn.js": "^5.2.0",
     "ffi-napi": "^3.1.0"
   },
   "devDependencies": {

--- a/src/starkware/crypto/ffi/portable_endian.h
+++ b/src/starkware/crypto/ffi/portable_endian.h
@@ -1,0 +1,112 @@
+#ifndef STARKWARE_CRYPTO_FFI_PORTABLE_ENDIAN_H_
+#define STARKWARE_CRYPTO_FFI_PORTABLE_ENDIAN_H_
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+
+#   define __WINDOWS__
+
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+
+#   include <endian.h>
+
+#elif defined(__APPLE__)
+
+#   include <libkern/OSByteOrder.h>
+
+#   define htobe16(x) OSSwapHostToBigInt16(x)
+#   define htole16(x) OSSwapHostToLittleInt16(x)
+#   define be16toh(x) OSSwapBigToHostInt16(x)
+#   define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#   define htobe32(x) OSSwapHostToBigInt32(x)
+#   define htole32(x) OSSwapHostToLittleInt32(x)
+#   define be32toh(x) OSSwapBigToHostInt32(x)
+#   define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#   define htobe64(x) OSSwapHostToBigInt64(x)
+#   define htole64(x) OSSwapHostToLittleInt64(x)
+#   define be64toh(x) OSSwapBigToHostInt64(x)
+#   define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#   define __BYTE_ORDER    BYTE_ORDER
+#   define __BIG_ENDIAN    BIG_ENDIAN
+#   define __LITTLE_ENDIAN LITTLE_ENDIAN
+#   define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__OpenBSD__)
+
+#   include <sys/endian.h>
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+
+#   include <sys/endian.h>
+
+#   define be16toh(x) betoh16(x)
+#   define le16toh(x) letoh16(x)
+
+#   define be32toh(x) betoh32(x)
+#   define le32toh(x) letoh32(x)
+
+#   define be64toh(x) betoh64(x)
+#   define le64toh(x) letoh64(x)
+
+#elif defined(__WINDOWS__)
+
+#   include <winsock2.h>
+#   include <sys/param.h>
+
+#   if BYTE_ORDER == LITTLE_ENDIAN
+
+#      define htobe16(x) htons(x)
+#      define htole16(x) (x)
+#      define be16toh(x) ntohs(x)
+#      define le16toh(x) (x)
+
+#      define htobe32(x) htonl(x)
+#      define htole32(x) (x)
+#      define be32toh(x) ntohl(x)
+#      define le32toh(x) (x)
+
+#      define htobe64(x) htonll(x)
+#      define htole64(x) (x)
+#      define be64toh(x) ntohll(x)
+#      define le64toh(x) (x)
+
+#   elif BYTE_ORDER == BIG_ENDIAN
+
+      /* that would be xbox 360 */
+#      define htobe16(x) (x)
+#      define htole16(x) __builtin_bswap16(x)
+#      define be16toh(x) (x)
+#      define le16toh(x) __builtin_bswap16(x)
+
+#      define htobe32(x) (x)
+#      define htole32(x) __builtin_bswap32(x)
+#      define be32toh(x) (x)
+#      define le32toh(x) __builtin_bswap32(x)
+
+#      define htobe64(x) (x)
+#      define htole64(x) __builtin_bswap64(x)
+#      define be64toh(x) (x)
+#      define le64toh(x) __builtin_bswap64(x)
+
+#   else
+
+#      error byte order not supported
+
+#   endif
+
+#   define __BYTE_ORDER    BYTE_ORDER
+#   define __BIG_ENDIAN    BIG_ENDIAN
+#   define __LITTLE_ENDIAN LITTLE_ENDIAN
+#   define __PDP_ENDIAN    PDP_ENDIAN
+
+#else
+
+#   error platform not supported
+
+#endif
+
+#endif  // STARKWARE_CRYPTO_FFI_PORTABLE_ENDIAN_H_

--- a/src/starkware/crypto/ffi/utils.cc
+++ b/src/starkware/crypto/ffi/utils.cc
@@ -1,8 +1,8 @@
-#include <endian.h>
 #include <algorithm>
 #include <cstring>
 
 #include "starkware/crypto/ffi/utils.h"
+#include "starkware/crypto/ffi/portable_endian.h"
 
 namespace starkware {
 

--- a/src/starkware/starkex/CMakeLists.txt
+++ b/src/starkware/starkex/CMakeLists.txt
@@ -2,5 +2,5 @@ add_library(starkex order.cc)
 target_link_libraries(starkex crypto)
 
 add_executable(order_test order_test.cc)
-target_link_libraries(order_test starkex gtest gtest_main pthread)
+target_link_libraries(order_test starkex gtest gtest_main gmock pthread)
 add_test(order_test order_test)

--- a/src/starkware/utils/CMakeLists.txt
+++ b/src/starkware/utils/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(math_test math_test.cc)
-target_link_libraries(math_test gtest gtest_main pthread)
+target_link_libraries(math_test gtest gtest_main gmock pthread)
 add_test(math_test math_test)
 
 add_executable(prng_test prng_test.cc)
-target_link_libraries(prng_test gtest gtest_main pthread)
+target_link_libraries(prng_test gtest gtest_main gmock pthread)
 add_test(prng_test prng_test)


### PR DESCRIPTION
Please note that I am not a C++ expert, so I'll appreciate all feedback.
I included all changes necessary to get it working on my machine, but in the meantime some problems were fixed by other PRs. Starknet.py uses this code to build native code (https://github.com/software-mansion/starknet.py).

Changes:

- Added gtest as recommended in https://google.github.io/googletest/quickstart-cmake.html and added gmock to target_link_libraries for tests.
- Made src/starkware/crypto/ffi/js/CMakeLists.txt copy either .so or .dylib files.
- Added portable endian header to allow compillation of platforms that don't support endian.h based on https://github.com/sahlberg/libsmb2/blob/master/include/portable-endian.h. https://github.com/starkware-libs/crypto-cpp/pull/4 includes headers for Apple devices.
- Replaced bn with bn.js in js package to fix js tests. https://github.com/starkware-libs/crypto-cpp/pull/7 fixes it as well.
- Added uint128 substitute for 32 bit platforms using [boost](https://www.boost.org/doc/libs/1_72_0/libs/multiprecision/doc/html/boost_multiprecision/intro.html).