### PR TITLE
Fix htole64 and le64toh missing on non-linux platforms

### DIFF
--- a/src/starkware/crypto/ffi/portable_endian.h
+++ b/src/starkware/crypto/ffi/portable_endian.h
@@ -1,0 +1,112 @@
+#ifndef STARKWARE_CRYPTO_FFI_PORTABLE_ENDIAN_H_
+#define STARKWARE_CRYPTO_FFI_PORTABLE_ENDIAN_H_
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+
+#   define __WINDOWS__
+
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+
+#   include <endian.h>
+
+#elif defined(__APPLE__)
+
+#   include <libkern/OSByteOrder.h>
+
+#   define htobe16(x) OSSwapHostToBigInt16(x)
+#   define htole16(x) OSSwapHostToLittleInt16(x)
+#   define be16toh(x) OSSwapBigToHostInt16(x)
+#   define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#   define htobe32(x) OSSwapHostToBigInt32(x)
+#   define htole32(x) OSSwapHostToLittleInt32(x)
+#   define be32toh(x) OSSwapBigToHostInt32(x)
+#   define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#   define htobe64(x) OSSwapHostToBigInt64(x)
+#   define htole64(x) OSSwapHostToLittleInt64(x)
+#   define be64toh(x) OSSwapBigToHostInt64(x)
+#   define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#   define __BYTE_ORDER    BYTE_ORDER
+#   define __BIG_ENDIAN    BIG_ENDIAN
+#   define __LITTLE_ENDIAN LITTLE_ENDIAN
+#   define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__OpenBSD__)
+
+#   include <sys/endian.h>
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+
+#   include <sys/endian.h>
+
+#   define be16toh(x) betoh16(x)
+#   define le16toh(x) letoh16(x)
+
+#   define be32toh(x) betoh32(x)
+#   define le32toh(x) letoh32(x)
+
+#   define be64toh(x) betoh64(x)
+#   define le64toh(x) letoh64(x)
+
+#elif defined(__WINDOWS__)
+
+#   include <winsock2.h>
+#   include <sys/param.h>
+
+#   if BYTE_ORDER == LITTLE_ENDIAN
+
+#      define htobe16(x) htons(x)
+#      define htole16(x) (x)
+#      define be16toh(x) ntohs(x)
+#      define le16toh(x) (x)
+
+#      define htobe32(x) htonl(x)
+#      define htole32(x) (x)
+#      define be32toh(x) ntohl(x)
+#      define le32toh(x) (x)
+
+#      define htobe64(x) htonll(x)
+#      define htole64(x) (x)
+#      define be64toh(x) ntohll(x)
+#      define le64toh(x) (x)
+
+#   elif BYTE_ORDER == BIG_ENDIAN
+
+      /* that would be xbox 360 */
+#      define htobe16(x) (x)
+#      define htole16(x) __builtin_bswap16(x)
+#      define be16toh(x) (x)
+#      define le16toh(x) __builtin_bswap16(x)
+
+#      define htobe32(x) (x)
+#      define htole32(x) __builtin_bswap32(x)
+#      define be32toh(x) (x)
+#      define le32toh(x) __builtin_bswap32(x)
+
+#      define htobe64(x) (x)
+#      define htole64(x) __builtin_bswap64(x)
+#      define be64toh(x) (x)
+#      define le64toh(x) __builtin_bswap64(x)
+
+#   else
+
+#      error byte order not supported
+
+#   endif
+
+#   define __BYTE_ORDER    BYTE_ORDER
+#   define __BIG_ENDIAN    BIG_ENDIAN
+#   define __LITTLE_ENDIAN LITTLE_ENDIAN
+#   define __PDP_ENDIAN    PDP_ENDIAN
+
+#else
+
+#   error platform not supported
+
+#endif
+
+#endif  // STARKWARE_CRYPTO_FFI_PORTABLE_ENDIAN_H_

--- a/src/starkware/crypto/ffi/utils.cc
+++ b/src/starkware/crypto/ffi/utils.cc
@@ -1,4 +1,3 @@
-#include <endian.h>
 #include <algorithm>
 #include <cstring>
 

--- a/src/starkware/crypto/ffi/utils.cc
+++ b/src/starkware/crypto/ffi/utils.cc
@@ -3,6 +3,7 @@
 #include <cstring>
 
 #include "starkware/crypto/ffi/utils.h"
+#include "starkware/crypto/ffi/portable_endian.h"
 
 namespace starkware {
 


### PR DESCRIPTION
Split from https://github.com/starkware-libs/crypto-cpp/pull/11