### PR TITLE
Add support for platforms without 128bit integers by using boost library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,32 @@ include_directories(${GTEST_INCLUDE_DIRS})
 enable_testing()
 include_directories("${CMAKE_SOURCE_DIR}/src")
 
+# Include boost in case target platform doesn't support uint128
+INCLUDE(CheckCXXSourceCompiles)
+check_cxx_source_compiles("
+int main() {
+  __uint128_t a = 0;
+  return 0;
+}" HAVE_UINT128)
+
+if (NOT HAVE_UINT128)
+  FetchContent_Declare(
+    boostorg
+    URL https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz
+  )
+
+  FetchContent_GetProperties(boostorg)
+  if (NOT boostorg_POPULATED)
+      FetchContent_Populate(boostorg)
+  endif ()
+
+  include_directories(${boostorg_SOURCE_DIR})
+
+  # For Windows: Prevent overriding the parent project's compiler/linker settings
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  FetchContent_MakeAvailable(boostorg)
+endif()
+
 if (NOT DEFINED CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ if (NOT HAVE_UINT128)
   FetchContent_Declare(
     boostorg
     URL https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz
+    URL_HASH SHA256=273f1be93238a068aba4f9735a4a2b003019af067b9c183ed227780b8f36062c
   )
 
   FetchContent_GetProperties(boostorg)

--- a/src/starkware/algebra/big_int.h
+++ b/src/starkware/algebra/big_int.h
@@ -13,6 +13,14 @@
 #include "starkware/utils/error_handling.h"
 #include "starkware/utils/prng.h"
 
+/*
+    Support for 32-bit builds, where __uint128_t isn't defined.
+*/
+#ifndef __SIZEOF_INT128__
+  #include <boost/multiprecision/cpp_int.hpp>
+  typedef boost::multiprecision::uint128_t __uint128_t;
+#endif
+
 namespace starkware {
 
 static constexpr inline __uint128_t Umul128(uint64_t x, uint64_t y) {


### PR DESCRIPTION
Split from https://github.com/starkware-libs/crypto-cpp/pull/11 and added automatic boost download when target doesn't support 128 bit integers.
https://www.boost.org/doc/libs/1_72_0/libs/multiprecision/doc/html/boost_multiprecision/intro.html