### PR TITLE
Add copying any shared lib, not only .so files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /.vscode/
 node_modules
 *.so
+*.dylib
 package-lock.json

--- a/src/starkware/crypto/ffi/js/CMakeLists.txt
+++ b/src/starkware/crypto/ffi/js/CMakeLists.txt
@@ -1,14 +1,14 @@
 add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto${CMAKE_SHARED_LIBRARY_SUFFIX}
     COMMAND
         ${CMAKE_COMMAND} -E copy
-        ${CMAKE_CURRENT_BINARY_DIR}/../libcrypto_c_exports.*
+        ${CMAKE_CURRENT_BINARY_DIR}/../libcrypto_c_exports${CMAKE_SHARED_LIBRARY_SUFFIX}
         ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS crypto_c_exports
 )
 
 add_custom_target(js_test ALL
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto${CMAKE_SHARED_LIBRARY_SUFFIX}
 )
 
 add_test(

--- a/src/starkware/crypto/ffi/js/CMakeLists.txt
+++ b/src/starkware/crypto/ffi/js/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto${CMAKE_SHARED_LIBRARY_SUFFIX}
+    OUTPUT libcrypto${CMAKE_SHARED_LIBRARY_SUFFIX}
     COMMAND
         ${CMAKE_COMMAND} -E copy
         ${CMAKE_CURRENT_BINARY_DIR}/../libcrypto_c_exports${CMAKE_SHARED_LIBRARY_SUFFIX}
@@ -8,7 +8,7 @@ add_custom_command(
 )
 
 add_custom_target(js_test ALL
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto${CMAKE_SHARED_LIBRARY_SUFFIX}
+    DEPENDS libcrypto${CMAKE_SHARED_LIBRARY_SUFFIX}
 )
 
 add_test(

--- a/src/starkware/crypto/ffi/js/CMakeLists.txt
+++ b/src/starkware/crypto/ffi/js/CMakeLists.txt
@@ -1,14 +1,14 @@
 add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto_c_exports.so
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto
     COMMAND
         ${CMAKE_COMMAND} -E copy
-        ${CMAKE_CURRENT_BINARY_DIR}/../libcrypto_c_exports.so
-        ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto_c_exports.so
+        ${CMAKE_CURRENT_BINARY_DIR}/../libcrypto_c_exports.*
+        ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS crypto_c_exports
 )
 
 add_custom_target(js_test ALL
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto_c_exports.so
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libcrypto
 )
 
 add_test(


### PR DESCRIPTION
Split from https://github.com/starkware-libs/crypto-cpp/pull/11/. Makes it possible to copy .{so, dylib, dll} files