### PR TITLE
Fixed return type of Verify function in ffi/ecdsa.cc

### DIFF
--- a/src/starkware/crypto/ffi/ecdsa.cc
+++ b/src/starkware/crypto/ffi/ecdsa.cc
@@ -33,7 +33,7 @@ extern "C" int GetPublicKey(
   return 0;
 }
 
-extern "C" bool Verify(
+extern "C" int Verify(
     const gsl::byte stark_key[kElementSize], const gsl::byte msg_hash[kElementSize],
     const gsl::byte r_bytes[kElementSize], const gsl::byte w_bytes[kElementSize]) {
   try {


### PR DESCRIPTION
In `ffi/ecdsa.h` the interface of Verify method is as follows:
```c
int Verify(const char* stark_key, const char* msg_hash, const char* r_bytes, const char* w_bytes);
```
but in `ffi/ecdsa.cc` it had a bool type.

The problem it caused:
I compiled crypto-cpp for Release (with -O3 flag), for ios and macos targets. On x86 macos target, calling Verify function would return very big numbers instead of 0 or 1. 